### PR TITLE
Fix the reading timeout of the HTTP socket

### DIFF
--- a/HDHRProxyIPTV/include/Transport.h
+++ b/HDHRProxyIPTV/include/Transport.h
@@ -33,7 +33,7 @@
 #define RTP_TS 2
 #define HTTP_TS 3
 
-#define BLOCKING_WAIT_TIME 4000  // Miliseconds to block TCP socket read operations!
+#define BLOCKING_WAIT_TIME 75  // Miliseconds to block TCP socket read operations!
 
 class CTransport
 {


### PR DESCRIPTION
When reading from the HTTP TCP socket, use small timeouts; and fill after the timeout the buffer with one 7 NULL PADDING packets.